### PR TITLE
fix bugs

### DIFF
--- a/utils/run_ida_script.py
+++ b/utils/run_ida_script.py
@@ -20,7 +20,7 @@ class Ctx:
         if "IDA_DIR" not in os.environ.keys():
             errx(self, "missing IDA_DIR environment variable")
 
-        self.ida_dir = os.path.abspath(os.environ["IDA_DIR"])
+        self.ida_dir = os.path.abspath(os.environ["IDA_DIR"].strip('"\''))
         # log(f"* IDA_DIR:\t{self.ida_dir}")
         suffix = ".exe" if sys.platform == "win32" else ""
         self.ida32 = os.path.join(self.ida_dir, "idat" + suffix)
@@ -95,7 +95,7 @@ def run_ida(ctx: Ctx, input_file: str, script: str, script_args: [str] = []):
     code = process.wait()
 
     output = ""
-    with open(ctx.logfile, "r") as fh:
+    with open(ctx.logfile, "r", encoding = "UTF-8") as fh:
         output = fh.read()
 
     if code == 0:

--- a/wdf_plugin/wdf.py
+++ b/wdf_plugin/wdf.py
@@ -238,7 +238,7 @@ def get_version_from_call(frm) -> str:
     """
     args_addrs = idaapi.get_arg_addrs(frm)
 
-    if len(args_addrs) != 4:
+    if args_addrs == None or len(args_addrs) != 4:
         return None, None
 
     insn = idautils.DecodeInstruction(args_addrs[2])  # BindInfo is the 3rd argument

--- a/wdfalyzer.py
+++ b/wdfalyzer.py
@@ -7,7 +7,7 @@ if "IDA_DIR" not in os.environ.keys():
     print("fatal: missing IDA_DIR environment variable")
     sys.exit(1)
 
-ida_dir = os.path.abspath(os.environ["IDA_DIR"])
+ida_dir = os.path.abspath(os.environ["IDA_DIR"].strip('"\''))
 ida_plugins_dir = os.path.abspath(os.path.join(ida_dir, "plugins"))
 idat = "idat64.exe" if os.name == "nt" else "idat64"
 idat_filepath = os.path.join(ida_dir, idat)
@@ -70,7 +70,7 @@ def make_til():
         print("Failed to create WDF typelibs. See til_creator_output.txt")
         sys.exit(1)
 
-    with open("til_creator_output.txt", "r") as f:
+    with open("til_creator_output.txt", "r", encoding = "UTF-8") as f:
         for line in f:
             if line.startswith("Created"):
                 print(line, end="")


### PR DESCRIPTION
Hi, thanks for the project. It saves me tons of time.

This pr aims to fix some bugs I encountered, including:

### 1. Retrieve the correct binary path
If there are quotes in IDA_DIR，`os.path.abspath` will return wrong results, for example:
```python
-> ida_dir = os.path.abspath(os.environ["IDA_DIR"])
(Pdb++) os.environ["IDA_DIR"]
'"D:\\Tools\\IDA_Pro_v8.3_Portable"'
(Pdb++) os.path.abspath(os.environ["IDA_DIR"])
'C:\\Users\\M4x\\Downloads\\ida_kmdf\\"D:\\Tools\\IDA_Pro_v8.3_Portable"'
(Pdb++) os.path.abspath("D:\\Tools\\IDA_Pro_v8.3_Portable")
'D:\\Tools\\IDA_Pro_v8.3_Portable'
```
 Quotes in IDA_DIR is not so rare. Especially the folder of IDA contains spaces or the user finds the folder in Explorer, right-clicks it, and selects "Copy as Path".


### 2. Avoid raising exception when `idaapi.get_arg_addrs` returns None
`idaapi.get_arg_addrs` will return None when xref the following address, resulting exception
```assembly
.text:00000001400293E9
.text:00000001400293E9
.text:00000001400293E9 ; Attributes: thunk
.text:00000001400293E9
.text:00000001400293E9 ; __int64 __fastcall WdfVersionBind(__int64, __int64, __int64, __int64)
.text:00000001400293E9 WdfVersionBind proc near
.text:00000001400293E9 jmp     cs:__imp_WdfVersionBind
.text:00000001400293E9 WdfVersionBind endp
.text:00000001400293E9
```


### 3. Use UTF-8 when opening files to avoid encoding/decoding problems
I met encoding/decoding problems when logging. Opening files as UTF-8 is better, I think.